### PR TITLE
Fixes error that occurred when column names referred to in a design matrix began with numbers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: OmicLoupe
 Title: OmicLoupe: Taking a closer look at omics
-Version: 1.1.6
+Version: 1.1.7
 Maintainer: Jakob Willforss <jakob.willforss@hotmail.com>
 Author: Jakob Willforss
 Authors@R: c(person("Jakob", "Willforss", email="jakob.willforss@hotmail.com", role=c("aut", "cre")))

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+# Version 1.1.7
+
+* Fixes error that occurred when column names referred to in a design matrix began with numbers or other disallowed characters
+* Silences warning on startup about useShinyalert
+
 # Version 1.1.6
 
 * Add Dockerfile

--- a/R/module_setup.R
+++ b/R/module_setup.R
@@ -11,7 +11,6 @@ setup_panel_ui <- function(id) {
         fluidPage(
             id = "outer_area",
             shinyjs::useShinyjs(),
-            shinyalert::useShinyalert(),
             tags$head(
                 tags$link(rel = "stylesheet", type = "text/css", href = "bootstrap")
             ),

--- a/R/reactive_values.R
+++ b/R/reactive_values.R
@@ -8,17 +8,23 @@ setup_reactive_values_obj <- function(input) {
         stringi::stri_extract_first(str = infile$name, regex = ".*")
     }
 
-    load_data <- function(in_file, two_datasets=NULL) {
+    load_data <- function(in_file, two_datasets=NULL, is_design_file = FALSE) {
         infile <- in_file
         if (is.null(infile) || (is.logical(two_datasets) && two_datasets==FALSE)) {
             return(NULL)
         }
         raw_df <- read_tsv(infile$datapath, col_types = cols())
 
-        original_colnames <- colnames(raw_df)
-        corrected_colnames <- make.names(colnames(raw_df))
 
-        colnames(raw_df) <- make.names(colnames(raw_df))
+        if (is_design_file) {
+            raw_df <- raw_df %>%
+              mutate_all(make.names)
+        } else {
+          original_colnames <- colnames(raw_df)
+          corrected_colnames <- make.names(colnames(raw_df))
+          colnames(raw_df) <- make.names(colnames(raw_df))
+        }
+
         raw_df
     }
 
@@ -26,13 +32,13 @@ setup_reactive_values_obj <- function(input) {
     rv$setup_input <- reactive(input)
     rv$filedata_1 <- reactive(load_data(input$data_file_1))
     rv$filedata_2 <- reactive(load_data(input$data_file_2, input$two_datasets))
-    rv$design_1 <- reactive(load_data(input$design_file_1))
+    rv$design_1 <- reactive(load_data(input$design_file_1, is_design_file = TRUE))
     rv$design_2 <- reactive({
         if (!input$matched_samples) {
-            load_data(input$design_file_2)
+            load_data(input$design_file_2, is_design_file = TRUE)
         }
         else {
-            load_data(input$design_file_1)
+            load_data(input$design_file_1, is_design_file = TRUE)
         }
     })
     rv$design_samplecol_1 <- reactive(input$design_sample_col_1)

--- a/R/reactive_values.R
+++ b/R/reactive_values.R
@@ -18,7 +18,7 @@ setup_reactive_values_obj <- function(input) {
 
         if (is_design_file) {
             raw_df <- raw_df %>%
-              mutate_all(make.names) # Run make.names on all elements of the design matrix
+              mutate_all(make.names) # Run make.names on all variables of the design matrix
         } else {
           colnames(raw_df) <- make.names(colnames(raw_df))
         }

--- a/R/reactive_values.R
+++ b/R/reactive_values.R
@@ -18,10 +18,8 @@ setup_reactive_values_obj <- function(input) {
 
         if (is_design_file) {
             raw_df <- raw_df %>%
-              mutate_all(make.names)
+              mutate_all(make.names) # Run make.names on all elements of the design matrix
         } else {
-          original_colnames <- colnames(raw_df)
-          corrected_colnames <- make.names(colnames(raw_df))
           colnames(raw_df) <- make.names(colnames(raw_df))
         }
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ After installation, you can immediately run the program.
 You can subsequently navigate to the browser to access the software.
 
 ```{r}
-> OmicLoupe::runApp()
+OmicLoupe::runApp()
 ```
 
 ## Dependencies


### PR DESCRIPTION
Previously, there would be an error when column names referred to in a design matrix began with numbers. These changes fix this, by running make.names on all elements of the design matrix.

Also, a ">" was removed from the instructions in the README, to make copy-pasting the command easier.

The updated version has been tested with various design matrices and appears to work well. 